### PR TITLE
fix: provide go.sum path for cached builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: go/go.sum
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache-dependency-path: go/go.sum
 
       - name: Setup buf
         uses: bufbuild/buf-setup-action@v1


### PR DESCRIPTION
- Eliminate the cache warning
- Enable Go module dependency caching
- Speed up workflow runs by caching downloaded dependencies